### PR TITLE
fix: schema.prisma

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -10,82 +10,58 @@ datasource db {
   url      = env("DATABASE_URL")
 }
 
+model User {
+  id                    String     @id @default(uuid()) @map("_id")
+  name                  String
+  email                 String?    @unique
+  emailVerified         DateTime?   @map("email_verified")
+  image                 String?
+  createdAt             DateTime   @default(now())
+  updatedAt             DateTime   @updatedAt
+  accounts              Account[]
+  sessions              Session[]
+  @@map("users")
+}
 model Account {
-  id                String  @id @default(cuid()) @map("_id")
-  userId            String
-  type              String
-  provider          String
-  providerAccountId String
-  refresh_token     String?
-  access_token      String?
-  expires_at        Int?
-  token_type        String?
-  scope             String?
-  id_token          String?
-  session_state     String?
-
-  user User @relation(fields: [userId], references: [id], onDelete: Cascade)
+  id                 String    @id @default(cuid()) @map("_id")
+  userId              String    @map("user_id")
+  type                 String?
+  provider           String
+  providerAccountId  String    @map("provider_account_id")
+  token_type         String?
+  refresh_token      String?   
+  access_token       String?   
+  expires_at         Int?
+  scope              String?
+  id_token           String? 
+  createdAt          DateTime  @default(now())
+  updatedAt          DateTime  @updatedAt
+  user               User      @relation(fields: [userId], references: [id], onDelete: Cascade)
 
   @@unique([provider, providerAccountId])
+  @@map("accounts")
 }
 
 model Session {
   id           String   @id @default(cuid()) @map("_id")
-  sessionToken String   @unique
-  userId       String
+  userId       String?  @map("user_id")
+  sessionToken String    @map("session_token") @unique
+  accessToken  String?   @map("access_token")
   expires      DateTime
-  user         User     @relation(fields: [userId], references: [id], onDelete: Cascade)
+  user         User?     @relation(fields: [userId], references: [id], onDelete: Cascade)
+  createdAt    DateTime @default(now())
+  updatedAt    DateTime @updatedAt
+
+  @@map("sessions")
 }
 
-model User {
-  id            String    @id @default(cuid()) @map("_id")
-  name          String?
-  email         String    @unique
-  emailVerified DateTime?
-  image         String?
-  accounts      Account[]
-  sessions      Session[]
-  Post          Post[]
-  Comment       Comment[]
-}
-
-model VerificationToken {
-  identifier String   @id @map("_id")
+model VerificationRequest {
+  id         String   @id @default(cuid()) @map("_id")
+  identifier String
   token      String   @unique
   expires    DateTime
+  createdAt  DateTime @default(now())
+  updatedAt  DateTime @updatedAt
 
   @@unique([identifier, token])
-}
-
-model Category {
-  id    String  @id @default(cuid()) @map("_id")
-  slug  String  @unique
-  title String
-  img   String?
-  Posts Post[]
-}
-
-model Post {
-  id        String    @id @default(cuid()) @map("_id")
-  createdAt DateTime  @default(now())
-  slug      String    @unique
-  title     String
-  desc      String
-  img       String?
-  views     Int       @default(0)
-  catSlug   String
-  cat       Category  @relation(fields: [catSlug], references: [slug])
-  userEmail String
-  user      User      @relation(fields: [userEmail], references: [email])
-  comments  Comment[]
-}
-
-model Comment {
-  id        String   @id @default(cuid()) @map("_id")
-  createdAt DateTime @default(now())
-  desc      String
-  userEmail String
-  user      User     @relation(fields: [userEmail], references: [email])
-  postSlug  String
-  post      Post     @relation(fields: [postSlug], references: [slug])
 }

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -11,32 +11,36 @@ datasource db {
 }
 
 model User {
-  id                    String     @id @default(uuid()) @map("_id")
-  name                  String
-  email                 String?    @unique
-  emailVerified         DateTime?   @map("email_verified")
-  image                 String?
-  createdAt             DateTime   @default(now())
-  updatedAt             DateTime   @updatedAt
-  accounts              Account[]
-  sessions              Session[]
+  id            String    @id @default(uuid()) @map("_id")
+  name          String
+  email         String    @unique
+  emailVerified DateTime? @map("email_verified")
+  image         String?
+  createdAt     DateTime  @default(now())
+  updatedAt     DateTime  @updatedAt
+  accounts      Account[]
+  sessions      Session[]
+  Post          Post[]
+  Comment       Comment[]
+
   @@map("users")
 }
+
 model Account {
-  id                 String    @id @default(cuid()) @map("_id")
-  userId              String    @map("user_id")
-  type                 String?
-  provider           String
-  providerAccountId  String    @map("provider_account_id")
-  token_type         String?
-  refresh_token      String?   
-  access_token       String?   
-  expires_at         Int?
-  scope              String?
-  id_token           String? 
-  createdAt          DateTime  @default(now())
-  updatedAt          DateTime  @updatedAt
-  user               User      @relation(fields: [userId], references: [id], onDelete: Cascade)
+  id                String   @id @default(cuid()) @map("_id")
+  userId            String   @map("user_id")
+  type              String?
+  provider          String
+  providerAccountId String   @map("provider_account_id")
+  token_type        String?
+  refresh_token     String?
+  access_token      String?
+  expires_at        Int?
+  scope             String?
+  id_token          String?
+  createdAt         DateTime @default(now())
+  updatedAt         DateTime @updatedAt
+  user              User     @relation(fields: [userId], references: [id], onDelete: Cascade)
 
   @@unique([provider, providerAccountId])
   @@map("accounts")
@@ -45,10 +49,10 @@ model Account {
 model Session {
   id           String   @id @default(cuid()) @map("_id")
   userId       String?  @map("user_id")
-  sessionToken String    @map("session_token") @unique
-  accessToken  String?   @map("access_token")
+  sessionToken String   @unique @map("session_token")
+  accessToken  String?  @map("access_token")
   expires      DateTime
-  user         User?     @relation(fields: [userId], references: [id], onDelete: Cascade)
+  user         User?    @relation(fields: [userId], references: [id], onDelete: Cascade)
   createdAt    DateTime @default(now())
   updatedAt    DateTime @updatedAt
 
@@ -64,4 +68,37 @@ model VerificationRequest {
   updatedAt  DateTime @updatedAt
 
   @@unique([identifier, token])
+}
+
+model Category {
+  id    String  @id @default(cuid()) @map("_id")
+  slug  String  @unique
+  title String
+  img   String?
+  Posts Post[]
+}
+
+model Post {
+  id        String   @id @default(cuid()) @map("_id")
+  createdAt DateTime @default(now())
+  slug      String   @unique
+  title     String
+  desc      String
+  img       String?
+  views     Int      @default(0)
+  catSlug   String
+  cat       Category @relation(fields: [catSlug], references: [slug])
+  userEmail String
+  user      User     @relation(fields: [userEmail], references: [email])
+  comments Comment[]
+}
+
+model Comment {
+  id        String @id @default(cuid()) @map("_id")
+  createdAt DateTime @default(now())
+  desc      String
+  userEmail String
+  user      User   @relation(fields: [userEmail], references: [email])
+  postSlug String
+  post      Post   @relation(fields: [postSlug], references: [slug])
 }


### PR DESCRIPTION
I had a problem with prisma schema and took 2 days to solve it. Basically i was not able to login with google auth. I get below error. I fix it via below issue on github and I just want to calobrate with solution. 

https://github.com/nextauthjs/next-auth/issues/3815

please do not forget to execute below code after you change your schema.prisma file 

`npx prisma db push`


file should be like below: 

// This is your Prisma schema file,
// learn more about it in the docs: https://pris.ly/d/prisma-schema

// This is your Prisma schema file,
// learn more about it in the docs: https://pris.ly/d/prisma-schema

generator client {
  provider = "prisma-client-js"
}

datasource db {
  provider = "mongodb"
  url      = env("DATABASE_URL")
}

model User {
  id            String    @id @default(uuid()) @map("_id")
  name          String
  email         String    @unique
  emailVerified DateTime? @map("email_verified")
  image         String?
  createdAt     DateTime  @default(now())
  updatedAt     DateTime  @updatedAt
  accounts      Account[]
  sessions      Session[]
  Post          Post[]
  Comment       Comment[]

  @@map("users")
}

model Account {
  id                String   @id @default(cuid()) @map("_id")
  userId            String   @map("user_id")
  type              String?
  provider          String
  providerAccountId String   @map("provider_account_id")
  token_type        String?
  refresh_token     String?
  access_token      String?
  expires_at        Int?
  scope             String?
  id_token          String?
  createdAt         DateTime @default(now())
  updatedAt         DateTime @updatedAt
  user              User     @relation(fields: [userId], references: [id], onDelete: Cascade)

  @@unique([provider, providerAccountId])
  @@map("accounts")
}

model Session {
  id           String   @id @default(cuid()) @map("_id")
  userId       String?  @map("user_id")
  sessionToken String   @unique @map("session_token")
  accessToken  String?  @map("access_token")
  expires      DateTime
  user         User?    @relation(fields: [userId], references: [id], onDelete: Cascade)
  createdAt    DateTime @default(now())
  updatedAt    DateTime @updatedAt

  @@map("sessions")
}

model VerificationRequest {
  id         String   @id @default(cuid()) @map("_id")
  identifier String
  token      String   @unique
  expires    DateTime
  createdAt  DateTime @default(now())
  updatedAt  DateTime @updatedAt

  @@unique([identifier, token])
}

model Category {
  id    String  @id @default(cuid()) @map("_id")
  slug  String  @unique
  title String
  img   String?
  Posts Post[]
}

model Post {
  id        String   @id @default(cuid()) @map("_id")
  createdAt DateTime @default(now())
  slug      String   @unique
  title     String
  desc      String
  img       String?
  views     Int      @default(0)
  catSlug   String
  cat       Category @relation(fields: [catSlug], references: [slug])
  userEmail String
  user      User     @relation(fields: [userEmail], references: [email])
  comments Comment[]
}

model Comment {
  id        String @id @default(cuid()) @map("_id")
  createdAt DateTime @default(now())
  desc      String
  userEmail String
  user      User   @relation(fields: [userEmail], references: [email])
  postSlug String
  post      Post   @relation(fields: [postSlug], references: [slug])
}


ERROR :

[next-auth][warn][NEXTAUTH_URL] 
https://next-auth.js.org/warnings#nextauth_url
[next-auth][error][adapter_error_getUserByAccount] 
https://next-auth.js.org/errors#adapter_error_getuserbyaccount 
Invalid `prisma.account.findUnique()` invocation:

{
  where: {
    provider_providerAccountId: {
    ~~~~~~~~~~~~~~~~~~~~~~~~~~
      providerAccountId: "secret",
      provider: "google"
    },
?   id?: String,
?   providerId_providerAccountId?: AccountProviderIdProviderAccountIdCompoundUniqueInput,
?   AND?: AccountWhereInput | AccountWhereInput[],
?   OR?: AccountWhereInput[],
?   NOT?: AccountWhereInput | AccountWhereInput[],
?   userId?: StringFilter | String,
?   providerType?: StringFilter | String,
?   providerId?: StringFilter | String,
?   providerAccountId?: StringFilter | String,
?   refreshToken?: StringNullableFilter | String | Null,
?   accessToken?: StringNullableFilter | String | Null,
?   accessTokenExpires?: DateTimeNullableFilter | DateTime | Null,
?   createdAt?: DateTimeFilter | DateTime,
?   updatedAt?: DateTimeFilter | DateTime,
?   user?: UserRelationFilter | UserWhereInput
  },
  select: {
    user: true
  }
}

Unknown argument `provider_providerAccountId`. Did you mean `providerId_providerAccountId`? Available options are listed in green. {
  message: '\n' +
    'Invalid `prisma.account.findUnique()` invocation:\n' +
    '\n' +
    '{\n' +
    '  where: {\n' +
    '    provider_providerAccountId: {\n' +
    '    ~~~~~~~~~~~~~~~~~~~~~~~~~~\n' +
    '      providerAccountId: "secret",\n' +
    '      provider: "google"\n' +
    '    },\n' +
    '?   id?: String,\n' +
    '?   providerId_providerAccountId?: AccountProviderIdProviderAccountIdCompoundUniqueInput,\n' +
    '?   AND?: AccountWhereInput | AccountWhereInput[],\n' +
    '?   OR?: AccountWhereInput[],\n' +
    '?   NOT?: AccountWhereInput | AccountWhereInput[],\n' +
    '?   userId?: StringFilter | String,\n' +
    '?   providerType?: StringFilter | String,\n' +
    '?   providerId?: StringFilter | String,\n' +
    '?   providerAccountId?: StringFilter | String,\n' +
    '?   refreshToken?: StringNullableFilter | String | Null,\n' +
    '?   accessToken?: StringNullableFilter | String | Null,\n' +
    '?   accessTokenExpires?: DateTimeNullableFilter | DateTime | Null,\n' +
    '?   createdAt?: DateTimeFilter | DateTime,\n' +
    '?   updatedAt?: DateTimeFilter | DateTime,\n' +
    '?   user?: UserRelationFilter | UserWhereInput\n' +
    '  },\n' +
    '  select: {\n' +
    '    user: true\n' +
    '  }\n' +
    '}\n' +
    '\n' +
    'Unknown argument `provider_providerAccountId`. Did you mean `providerId_providerAccountId`? Available options are listed in green.',
  stack: 'PrismaClientValidationError: \n' +
    'Invalid `prisma.account.findUnique()` invocation:\n' +
    '\n' +
    '{\n' +
    '  where: {\n' +
    '    provider_providerAccountId: {\n' +
    '    ~~~~~~~~~~~~~~~~~~~~~~~~~~\n' +
    '      providerAccountId: "secret",\n' +
    '      provider: "google"\n' +
    '    },\n' +
    '?   id?: String,\n' +
    '?   providerId_providerAccountId?: AccountProviderIdProviderAccountIdCompoundUniqueInput,\n' +
    '?   AND?: AccountWhereInput | AccountWhereInput[],\n' +
    '?   OR?: AccountWhereInput[],\n' +
    '?   NOT?: AccountWhereInput | AccountWhereInput[],\n' +
    '?   userId?: StringFilter | String,\n' +
    '?   providerType?: StringFilter | String,\n' +
    '?   providerId?: StringFilter | String,\n' +
    '?   providerAccountId?: StringFilter | String,\n' +
    '?   refreshToken?: StringNullableFilter | String | Null,\n' +
    '?   accessToken?: StringNullableFilter | String | Null,\n' +
    '?   accessTokenExpires?: DateTimeNullableFilter | DateTime | Null,\n' +
    '?   createdAt?: DateTimeFilter | DateTime,\n' +
    '?   updatedAt?: DateTimeFilter | DateTime,\n' +
    '?   user?: UserRelationFilter | UserWhereInput\n' +
    '  },\n' +
    '  select: {\n' +
    '    user: true\n' +
    '  }\n' +
    '}\n' +
    '\n' +
    'Unknown argument `provider_providerAccountId`. Did you mean `providerId_providerAccountId`? Available options are listed in green.\n' +
    '    at yn (/Users/cansurer/Documents/dev-workspace/next-react-blog/node_modules/@prisma/client/runtime/library.js:116:5852)\n' +
    '    at wn.handleRequestError (/Users/cansurer/Documents/dev-workspace/next-react-blog/node_modules/@prisma/client/runtime/library.js:123:6429)\n' +
    '    at wn.handleAndLogRequestError (/Users/cansurer/Documents/dev-workspace/next-react-blog/node_modules/@prisma/client/runtime/library.js:123:6119)\n' +
    '    at wn.request (/Users/cansurer/Documents/dev-workspace/next-react-blog/node_modules/@prisma/client/runtime/library.js:123:5839)\n' +
    '    at async l (/Users/cansurer/Documents/dev-workspace/next-react-blog/node_modules/@prisma/client/runtime/library.js:128:9763)\n' +
    '    at async getUserByAccount (webpack-internal:///(rsc)/./node_modules/@auth/prisma-adapter/index.js:220:29)',
  name: 'PrismaClientValidationError'
}
[next-auth][error][OAUTH_CALLBACK_HANDLER_ERROR] 
https://next-auth.js.org/errors#oauth_callback_handler_error 
Invalid `prisma.account.findUnique()` invocation:

{
  where: {
    provider_providerAccountId: {
    ~~~~~~~~~~~~~~~~~~~~~~~~~~
      providerAccountId: "101939472610204082780",
      provider: "google"
    },
?   id?: String,
?   providerId_providerAccountId?: AccountProviderIdProviderAccountIdCompoundUniqueInput,
?   AND?: AccountWhereInput | AccountWhereInput[],
?   OR?: AccountWhereInput[],
?   NOT?: AccountWhereInput | AccountWhereInput[],
?   userId?: StringFilter | String,
?   providerType?: StringFilter | String,
?   providerId?: StringFilter | String,
?   providerAccountId?: StringFilter | String,
?   refreshToken?: StringNullableFilter | String | Null,
?   accessToken?: StringNullableFilter | String | Null,
?   accessTokenExpires?: DateTimeNullableFilter | DateTime | Null,
?   createdAt?: DateTimeFilter | DateTime,
?   updatedAt?: DateTimeFilter | DateTime,
?   user?: UserRelationFilter | UserWhereInput
  },
  select: {
    user: true
  }
}

Unknown argument `provider_providerAccountId`. Did you mean `providerId_providerAccountId`? Available options are listed in green. PrismaClientValidationError: 
Invalid `prisma.account.findUnique()` invocation:

{
  where: {
    provider_providerAccountId: {
    ~~~~~~~~~~~~~~~~~~~~~~~~~~
      providerAccountId: "secret",
      provider: "google"
    },
?   id?: String,
?   providerId_providerAccountId?: AccountProviderIdProviderAccountIdCompoundUniqueInput,
?   AND?: AccountWhereInput | AccountWhereInput[],
?   OR?: AccountWhereInput[],
?   NOT?: AccountWhereInput | AccountWhereInput[],
?   userId?: StringFilter | String,
?   providerType?: StringFilter | String,
?   providerId?: StringFilter | String,
?   providerAccountId?: StringFilter | String,
?   refreshToken?: StringNullableFilter | String | Null,
?   accessToken?: StringNullableFilter | String | Null,
?   accessTokenExpires?: DateTimeNullableFilter | DateTime | Null,
?   createdAt?: DateTimeFilter | DateTime,
?   updatedAt?: DateTimeFilter | DateTime,
?   user?: UserRelationFilter | UserWhereInput
  },
  select: {
    user: true
  }
}

Unknown argument `provider_providerAccountId`. Did you mean `providerId_providerAccountId`? Available options are listed in green.
    at yn (/Users/cansurer/Documents/dev-workspace/next-react-blog/node_modules/@prisma/client/runtime/library.js:116:5852)
    at wn.handleRequestError (/Users/cansurer/Documents/dev-workspace/next-react-blog/node_modules/@prisma/client/runtime/library.js:123:6429)
    at wn.handleAndLogRequestError (/Users/cansurer/Documents/dev-workspace/next-react-blog/node_modules/@prisma/client/runtime/library.js:123:6119)
    at wn.request (/Users/cansurer/Documents/dev-workspace/next-react-blog/node_modules/@prisma/client/runtime/library.js:123:5839)
    at async l (/Users/cansurer/Documents/dev-workspace/next-react-blog/node_modules/@prisma/client/runtime/library.js:128:9763)
    at async getUserByAccount (webpack-internal:///(rsc)/./node_modules/@auth/prisma-adapter/index.js:220:29) {
  name: 'GetUserByAccountError',
  code: undefined
}